### PR TITLE
A possible bug in line 44

### DIFF
--- a/docs/equations/notation_twolayer_model.rst
+++ b/docs/equations/notation_twolayer_model.rst
@@ -41,7 +41,7 @@ where
 .. math::
 
 
-   F_1 \equiv \frac{k_d^2}{1 + \delta^2}\,, \qquad \text{and} \qquad F_2 \equiv \delta \,F_1\,,
+   F_1 \equiv \frac{k_d^2}{1 + \delta}\,, \qquad \text{and} \qquad F_2 \equiv \delta \,F_1\,,
 
 with the deformation wavenumber
 


### PR DESCRIPTION
It seems to me that \delta^2 for F_1 has to be \delta.
The line 124 in "qg_model.py" indeed use \delta to compute F_1.